### PR TITLE
Feedback changes from upstream PR

### DIFF
--- a/TagListView.podspec
+++ b/TagListView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TagListView"
-  s.version      = "1.3.2"
+  s.version      = "1.3.1"
   s.summary      = "Simple but highly customizable iOS tag list view, in Swift."
   s.homepage     = "https://github.com/ElaWorkshop/TagListView"
   s.social_media_url = "http://twitter.com/elabuild"

--- a/TagListView/CloseButton.swift
+++ b/TagListView/CloseButton.swift
@@ -29,7 +29,7 @@ internal class CloseButton: UIButton {
             height: iconSize
         )
 
-        // lineWidth/2 is so the edge of the stroke is not cut off
+        // If path starts at the edge of the frame, we only see half the width of the first part of the stroke. (The other half is outside the bounds of the frame, and are cut off.) Pulling the path in from the edges by lineWidth/2 allows the edge to not be cut off.
         path.move(to: CGPoint(x: iconFrame.minX + lineWidth/2, y: iconFrame.minY + lineWidth/2))
         path.addLine(to: CGPoint(x: iconFrame.maxX - lineWidth/2, y: iconFrame.maxY - lineWidth/2))
         path.move(to: CGPoint(x: iconFrame.maxX - lineWidth/2, y: iconFrame.minY + lineWidth/2))

--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -44,29 +44,29 @@ open class TagView: UIButton {
             titleLabel?.lineBreakMode = titleLineBreakMode
         }
     }
-    @IBInspectable open var paddingY: CGFloat = 2 {
-        didSet {
-            titleEdgeInsets.top = paddingY
-            titleEdgeInsets.bottom = paddingY
-        }
-    }
+    
     @IBInspectable open var paddingX: CGFloat = 5 {
         didSet {
             titleEdgeInsets.left = paddingX
             updateRightInsets()
         }
     }
-    
-    private var imagePaddingY: CGFloat {
-        // If both image and TagView are rounded, image should fit snugly into corner.
-        // If not, image should still be larger than text.
-        return hasOvalShape ? borderWidth : (paddingY / 2) + borderWidth
+    @IBInspectable open var paddingY: CGFloat = 2 {
+        didSet {
+            titleEdgeInsets.top = paddingY
+            titleEdgeInsets.bottom = paddingY
+        }
     }
     
     private var imagePaddingX: CGFloat {
-        // If both the image and TagView are rounded, left indent by Y padding so image snugly fits on left side of TagView
-        // If not, indent by half padding - full padding looks terrible.
-        return hasOvalShape ? imagePaddingY : (paddingX / 2)
+        // If both the image and TagView are rounded, left indent by the border width so image snugly fits on left side of TagView
+        // If not, indent by half paddingX - full paddingX w/ text looks unbalanced.
+        return hasOvalShape ? borderWidth : (paddingX / 2)
+    }
+    private var imagePaddingY: CGFloat {
+        // If both image and TagView are rounded, image should fit snugly into corner.
+        // If not, image should still be larger than text - use half the padding .
+        return hasOvalShape ? borderWidth : (paddingY / 2) + borderWidth
     }
     
     private var imageWidth: CGFloat {
@@ -196,8 +196,6 @@ open class TagView: UIButton {
         
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(self.longPress))
         self.addGestureRecognizer(longPress)
-        
-        imageView?.contentMode = .scaleAspectFit
     }
     
     @objc func longPress() {


### PR DESCRIPTION
Comments from upstream PR: https://github.com/ElaWorkshop/TagListView/pull/193#pullrequestreview-142205972

Please review @migfabio 
Attn: @Expensify/mobile 

Most changes were around comments and structure.

Also removed `contentMode` per request. I tested it, and we don't actually need this change. The default `scaleToFill` is the same as `scaleAspectFit` for square images.